### PR TITLE
added an 'end' event

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -49,7 +49,8 @@ function Carrier(reader, listener, encoding) {
       line = line.replace("\r", '');
       self.emit('line', line);
       line = '';
-    }  
+    }
+    self.emit('end');
   }
   
   reader.on('end', ender);


### PR DESCRIPTION
If I just listen for the `end` event of the underlying stream, I might miss the last line. Emitting an `end` event in the carrier seems to be a better solution.
