### PR TITLE
Fixed double call to end event.

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -54,7 +54,6 @@ function Carrier(reader, listener, encoding) {
   }
   
   reader.on('end', ender);
-  reader.on('close', ender);
 }
 
 util.inherits(Carrier, events.EventEmitter);


### PR DESCRIPTION
Having:

reader.on('end', ender);
reader.on('close', ender);

was causing the carrier to emit the end event twice.

Here's our git commit message:

Removed close event handler as it was causing self.emit('end') to be called twice.
