### PR TITLE
Simplify splitting logic.

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -10,44 +10,24 @@ function Carrier(reader, listener, encoding) {
     self.addListener('line', listener);
   }
   
-  var line = '';
+  var buffer = '';
   
   reader.setEncoding(encoding || 'utf-8');
   reader.on('data', function(data) {
-    var lines = data.split("\n");
-    if (data.charAt(data.length - 1) == "\n") {
-      // get rid of last "" after last "\n"
-      lines.pop(1);
-    }
-    
-    if (lines.length > 0) {
-      //console.log('Have ' + lines.length + " lines\n");
-      lines.forEach(function(one_line, index) {
-        line += one_line;
-        var emit = true;
-        if (index == lines.length - 1) {
-          // processing last line
-          if (data.charAt(data.length - 1) != "\n") {
-            // if it was not terminated by "\n" then the last line was not finished; we just buffer it.
-            //console.log('last one does not have \n, not emitting');
-            emit = false;
-          }
-        }
-        if (emit) {
-          line = line.replace("\r", '');
-          //console.log('emiting ' + line + "\n");
-          self.emit('line', line);          
-          line = '';
-        }
-      })
-    }
+    var lines = (buffer + data).split("\n");
+    buffer = lines.pop();
+
+    lines.forEach(function(line, index) {
+      line = line.replace("\r", '');
+      self.emit('line', line);
+    });
   });
   
   var ender = function() {
-    if (line.length > 0) {
-      line = line.replace("\r", '');
-      self.emit('line', line);
-      line = '';
+    if (buffer.length > 0) {
+      buffer = buffer.replace("\r", '');
+      self.emit('line', buffer);
+      buffer = '';
     }
     self.emit('end');
   }


### PR DESCRIPTION
I'm going to be bold here; this cuts a third in code in the main module. Tests pass. :)

The difference in thinking here is hidden in:

```
// get rid of last "" after last "\n"
```

That empty string can be considered the start of an unfinished line. The last element from the result of `split` will always be something unfinished / not terminated by a newline:

```
''.split('\n')          # => ['']            => buffer is ''
'foo'.split('\n')       # => ['foo']         => buffer is 'foo'
'foo\n'.split('\n')     # => ['foo', '']     => buffer is ''
'foo\nbar'.split('\n')  # => ['foo', 'bar']  => buffer is 'bar'
```

So you can basically concat the buffer and new data, then reuse the last element as the buffer for the next run:

```
var lines = (buffer + data).split("\n");
buffer = lines.pop();
```

Only at the very end of the stream do we need to prevent emitting an empty line. That can be easily checked, the buffer will be the empty string from the last `split`.
