### PR TITLE
avoid big string concatenation

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -18,7 +18,8 @@ function Carrier(reader, listener, encoding, separator) {
   
   reader.setEncoding(encoding || 'utf8');
   reader.on('data', function(data) {
-    var lines = (buffer + data).split(separator);
+    var lines = data.split(separator);
+    lines[0] && lines[0] = buffer + lines[0];
     buffer = lines.pop();
 
     lines.forEach(function(line, index) {


### PR DESCRIPTION
So if a stream fragment is too big, it to small string concatenation instead of the big string concatenation.
