### PR TITLE
streamify

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -1,43 +1,63 @@
-var util    = require('util'),
-    events = require('events');
+var util   = require('util'),
+    stream = require('stream');
 
 function Carrier(reader, listener, encoding, separator) {
+  stream.Stream.call(this);
   var self = this;
   
   self.reader = reader;
+  self.readable = reader.readable;
 
   if (!separator) {
     separator = /\r?\n/;
   }
 
   if (listener) {
-    self.addListener('line', listener);
+    self.addListener('data', listener);
   }
   
   var buffer = '';
   
-  reader.setEncoding(encoding || 'utf8');
   reader.on('data', function(data) {
     var lines = (buffer + data).split(separator);
     buffer = lines.pop();
 
     lines.forEach(function(line, index) {
-      self.emit('line', line);
+      self.emit('data', line);
     });
   });
   
   var ender = function() {
     if (buffer.length > 0) {
-      self.emit('line', buffer);
+      self.emit('data', buffer);
       buffer = '';
     }
+    self.readable = reader.readable;
     self.emit('end');
   }
   
   reader.on('end', ender);
+  reader.on('close', function () { self.emit('close') });
 }
 
-util.inherits(Carrier, events.EventEmitter);
+util.inherits(Carrier, stream.Stream);
+
+Carrier.prototype.pipe = function(dest, opts) {
+  stream.Stream.prototype.pipe.call(this, dest, opts);
+  return dest;
+}
+
+Carrier.prototype.pause = function() {
+  this.reader.pause.apply(this.reader, arguments);
+}
+
+Carrier.prototype.resume = function() {
+  this.reader.resume.apply(this.reader, arguments);
+}
+
+Carrier.prototype.destroy = function () {
+  this.reader.destroy();
+}
 
 exports.carry = function(reader, listener, encoding, separator) {
   return new Carrier(reader, listener, encoding, separator);

--- a/package.json
+++ b/package.json
@@ -32,7 +32,11 @@
   }
 , "directories" : { "lib" : "./lib" }
 , "engines" : { "node" : ">=0.3.0" }
-, "devDependencies": { "tap" : "0.2" }
+, "devDependencies":
+  { "tap" : "0.2"
+  , "stream-tester" : "git://github.com/dominictarr/stream-tester.git"
+  , "stream-spec" : "git://github.com/dominictarr/stream-spec.git"
+  }
 , "scripts" : { "test" : "tap test/*.js" }
 , "main": "./lib/carrier.js"
 , "licenses" :

--- a/test/test_stream.js
+++ b/test/test_stream.js
@@ -1,0 +1,12 @@
+var carrier = require('../lib/carrier.js');
+    spec    = require('stream-spec');
+	tester  = require('stream-tester');
+
+var strm = tester.createRandomStream(function () {
+	return 'line ' + Math.random()
+}, 1000)
+
+spec(carrier.carry(strm))
+	.readable()
+	.pausable({strict: true}) //strict is optional.
+	.validateOnExit()


### PR DESCRIPTION
I've added support for proper node streams to carrier, so now we can do this:

```
carrier.carry(stream).pipe(process.stdout)
```
