### PR TITLE
Add markdown syntax highlighting

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ The client can send you chunks of lines and carrier will only notify you on each
     $ npm install carrier
     
 ## Usage
-
+```javascript
     var net     = require('net'),
         carrier = require('carrier');
 
@@ -17,10 +17,10 @@ The client can send you chunks of lines and carrier will only notify you on each
       });
     });
     server.listen(4001);
-
+```
   
 Or, you can also listen to the "line" event on the returned object of carrier.carry() like this:
-
+```javascript
     var net     = require('net'),
         carrier = require('carrier');
 
@@ -31,11 +31,11 @@ Or, you can also listen to the "line" event on the returned object of carrier.ca
       });
     });
     server.listen(4001);
-
+```
 carrier.carry accepts the following options:
-
+```javascript
     carrier.carry(reader, listener, encoding, separator)
-
+```
 * reader: the stream reader
 * listener: a "line" event listener function
 * encoding: what encoding to assume. Default: "utf8"


### PR DESCRIPTION
This adds sytax highlighting (JS) to the README.md documentation.

Merging would be highly appreciated, because it makes the docs easier to read.
