### PR TITLE
Reduce amount of string concatenation to increase performance.

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -19,7 +19,7 @@ function Carrier(reader, listener, encoding, separator) {
   reader.setEncoding(encoding || 'utf8');
   reader.on('data', function(data) {
     var lines = data.split(separator);
-    data[0] = buffer + data[0];
+    lines[0] = buffer + lines[0];
     buffer = lines.pop();
 
     lines.forEach(function(line, index) {


### PR DESCRIPTION
Previously, the remaining buffer and the newly received data were
concatenated prior to splitting.

However, we know for sure that the remaining buffer is free of
seperators. That means we can split the newly received data first,
and then paste the remaining buffer in front of the first so
obtained line.

This change increases performance for large lines.
