### PR TITLE
Support Stream implementation that does not properly implement setEncoding.

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -3,6 +3,7 @@ var util    = require('util'),
 
 function Carrier(reader, listener, encoding, separator) {
   var self = this;
+  encoding = encoding || 'utf-8';
   
   self.reader = reader;
 
@@ -16,8 +17,12 @@ function Carrier(reader, listener, encoding, separator) {
   
   var buffer = '';
   
-  reader.setEncoding(encoding || 'utf8');
+  reader.setEncoding(encoding);
   reader.on('data', function(data) {
+    if (data instanceof Buffer) {
+      data = data.toString(encoding);
+    }
+
     var lines = data.split(separator);
     lines[0] = buffer + lines[0];
     buffer = lines.pop();

--- a/test/test_handle_buffer.js
+++ b/test/test_handle_buffer.js
@@ -1,0 +1,29 @@
+var net     = require('net'),
+    tap     = require('tap'),
+    carrier = require('../lib/carrier.js');
+
+tap.test("test Buffer handling (when setEncoding is not supported.)", function(t) {
+  var server;
+  var port = 4001;
+  var expected_line = 'hello world';
+  var to_be_sent = new Buffer('hello world\r\n');
+
+  t.plan(1);
+
+  server = net.createServer(function(conn) {
+    conn.setEncoding = function() { }; // simulate bad setEncoding impl.
+    carrier.carry(conn, function(line) {
+      t.equal(line, expected_line);
+    });
+  });
+  server.listen(port);
+
+  var client = net.createConnection(port);
+  client.on('connect', function() {
+    client.end(to_be_sent);
+  });
+
+  t.on("end", function() {
+    server.close();
+  });
+});


### PR DESCRIPTION
When I use carrier with a stream implementation that does not implement setEncoding I get errors like this:

``` sh
    var lines = data.split(separator);
                     ^
TypeError: Object hello world
 has no method 'split'
    at Socket.<anonymous> (/Users/chakrit/Documents/carrier/lib/carrier.js:21:22)
    at Socket.EventEmitter.emit (events.js:96:17)
    at TCP.onread (net.js:397:14)
```

This patch makes carrier checks wether incoming data is a `Buffer`, which it will be if the reader stream does not correctly implement setEncoding, and do a `toString(encoding)` to properly convert it to a string.

I think this is a fairly common case (custom Stream w/o setEncoding support.) so I think carrier should handles this.
