### PR TITLE
Added support for dgram sockets.

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -1,10 +1,13 @@
 var util    = require('util'),
-    events = require('events');
+    events = require('events'),
+    dgram   = require('dgram');
 
 function Carrier(reader, listener, encoding, separator) {
   var self = this;
   encoding = encoding || 'utf-8';
-  
+
+  var event = reader.constructor === dgram.Socket ? 'message' : 'data';
+
   self.reader = reader;
 
   if (!separator) {
@@ -14,11 +17,15 @@ function Carrier(reader, listener, encoding, separator) {
   if (listener) {
     self.addListener('line', listener);
   }
-  
+
   var buffer = '';
-  
-  reader.setEncoding(encoding);
-  reader.on('data', function(data) {
+
+  if (typeof reader.setEncoding === 'function')
+      reader.setEncoding(encoding);
+
+  reader.on(event, function(data) {
+    var args = Array.prototype.slice.call(arguments, 1);
+
     if (data instanceof Buffer) {
       data = data.toString(encoding);
     }
@@ -28,10 +35,15 @@ function Carrier(reader, listener, encoding, separator) {
     buffer = lines.pop();
 
     lines.forEach(function(line, index) {
-      self.emit('line', line);
+      var _args = args.slice(0);
+
+      _args.unshift(line);
+      _args.unshift('line');
+
+      self.emit.apply(self, _args);
     });
   });
-  
+
   var ender = function() {
     if (buffer.length > 0) {
       self.emit('line', buffer);
@@ -39,7 +51,7 @@ function Carrier(reader, listener, encoding, separator) {
     }
     self.emit('end');
   }
-  
+
   reader.on('end', ender);
 }
 


### PR DESCRIPTION
There are two main differences preventing carrier from being used with dgram-based sockets: 1) dgram doesn't support the setEncoding function, and the event that is fired on a message is different (along with the arguments passed). This patch aims to allow carrier to be used interchangeably between net and dgram sockets by 1) only calling setEncoding if it exists, and 2) listening for the appropriate event and firing the 'line' event with all of the passed arguments.
