### PR TITLE
move function from anonymous to enable v8 optimisation

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -8,22 +8,7 @@ function Carrier(reader, listener, encoding, separator) {
 
   var event = reader.constructor === dgram.Socket ? 'message' : 'data';
 
-  self.reader = reader;
-
-  if (!separator) {
-    separator = /\r?\n/;
-  }
-
-  if (listener) {
-    self.addListener('line', listener);
-  }
-
-  var buffer = '';
-
-  if (typeof reader.setEncoding === 'function')
-      reader.setEncoding(encoding);
-
-  reader.on(event, function(data) {
+  var onEvent = function carrierOnEvent(data) {
     var args = Array.prototype.slice.call(arguments, 1);
 
     if (data instanceof Buffer) {
@@ -42,7 +27,24 @@ function Carrier(reader, listener, encoding, separator) {
 
       defferredEmit.apply(self, _args);
     });
-  });
+  }
+
+  self.reader = reader;
+
+  if (!separator) {
+    separator = /\r?\n/;
+  }
+
+  if (listener) {
+    self.addListener('line', listener);
+  }
+
+  var buffer = '';
+
+  if (typeof reader.setEncoding === 'function')
+      reader.setEncoding(encoding);
+
+  reader.on(event, onEvent);
 
   var ender = function() {
     if (buffer.length > 0) {


### PR DESCRIPTION
This function is being called ALOT in my application, yes, this optimisation only gives you a few micro seconds but when you're calling it ALOT all of this helps

Shouldn't have changed the behaviour at all, All I've done is moved it out to its own declaration and named it so that when people do say `connection.listeners('data')` they don't just see `[Function]` , now they would see `[Function: carrierOnEvent]` - helps when debugging too :)

Let me know if you have any thoughts on why this shouldn't go in; thanks for the module!
