### PR TITLE
Fix end emitted before last line

### DIFF
--- a/lib/carrier.js
+++ b/lib/carrier.js
@@ -48,7 +48,9 @@ function Carrier(reader, listener, encoding, separator) {
       buffer = '';
     }
 
-    self.emit('end');
+    process.nextTick(function() {
+      self.emit('end');
+    });
   };
 
   reader.on(eventName, onData);

--- a/test/test_fast_end.js
+++ b/test/test_fast_end.js
@@ -1,0 +1,26 @@
+var util    = require('util'),
+    events  = require('events'),
+    tap     = require('tap'),
+    carrier = require('../lib/carrier.js');
+
+function R() {
+  this.readable = true;
+
+  var self = this;
+  process.nextTick(function() {
+    self.emit("data", "line1\nline2");
+    self.emit("end");
+  });
+}
+util.inherits(R, events.EventEmitter);
+
+tap.test("end is not emitted before last line", function(t) {
+  var lines = [];
+
+  carrier.carry(new R(), function(line) {
+    lines.push(line);
+  }).on('end', function() {
+    t.deepEqual(lines.slice(), ["line1", "line2"]);
+    t.end();
+  });
+});


### PR DESCRIPTION
The 0.2.x releases can emit `"end"` before all lines have been emitted. 
