### PR TITLE
Create .npmignore to prevent tests from being published to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules/
+.travis.yml
+test/


### PR DESCRIPTION
The npm publish contains this tree:

```
carrier
├── lib
│   └── carrier.js
├── LICENSE
├── .npmignore
├── package.json
├── README.markdown
├── test
│   ├── extra_carriage.js
│   ├── test_concatenation.js
│   ├── test_fast_end.js
│   ├── test_handle_buffer.js
│   ├── test_line_breaks.js
│   ├── test_no_br.js
│   ├── test_one_line_ending_in_nl.js
│   └── test_other_breaks.js
└── .travis.yml
```

technically only this tree would be needed, as far as I know:

```
carrier
├── lib
│   └── carrier.js
├── LICENSE
├── .npmignore
├── package.json
└── README.markdown
```

(Omitting `.travis.yml` and the `test` directory).

This PR corrects that by listing these files in `.npmignore`.